### PR TITLE
fix(event-details): shows 'GRATIS' when price is 0 or null

### DIFF
--- a/src/components/corporate/events/event-details.js
+++ b/src/components/corporate/events/event-details.js
@@ -84,7 +84,7 @@ const EventDetails = ({ event }) => {
                             </Box>
                             <Box>
                                 <Text fontSize={14} mt={3} fontWeight='bold' textDecor={'underline'}>Precio:</Text>
-                                <Text>{event.price === 0 ? 'GRATIS' : `${event.price} €`}</Text>
+                                <Text>{event.price === 0 || event.price === null ? 'GRATIS' : `${event.price} €`}</Text>
                             </Box>
                         </Flex>
 


### PR DESCRIPTION
![image_2025-06-04_162114443](https://github.com/user-attachments/assets/124308c4-79a9-47ec-8bd9-e7ab066e7bf3)
