### PR TITLE
feat(solution-detail): see more after 4 languages

### DIFF
--- a/src/components/corporate/events/event-details.js
+++ b/src/components/corporate/events/event-details.js
@@ -84,7 +84,7 @@ const EventDetails = ({ event }) => {
                             </Box>
                             <Box>
                                 <Text fontSize={14} mt={3} fontWeight='bold' textDecor={'underline'}>Precio:</Text>
-                                <Text>{event.price === 0 ? 'GRATIS' : `${event.price} €`}</Text>
+                                <Text>{event.price === 0 || event.price === null ? 'GRATIS' : `${event.price} €`}</Text>
                             </Box>
                         </Flex>
 

--- a/src/components/corporate/events/event-details.js
+++ b/src/components/corporate/events/event-details.js
@@ -84,7 +84,7 @@ const EventDetails = ({ event }) => {
                             </Box>
                             <Box>
                                 <Text fontSize={14} mt={3} fontWeight='bold' textDecor={'underline'}>Precio:</Text>
-                                <Text>{event.price === 0 || event.price === null ? 'GRATIS' : `${event.price} €`}</Text>
+                                <Text>{event.price === 0 ? 'GRATIS' : `${event.price} €`}</Text>
                             </Box>
                         </Flex>
 

--- a/src/components/corporate/solutions/solution-detail.js
+++ b/src/components/corporate/solutions/solution-detail.js
@@ -1,4 +1,4 @@
-import { Box, Text, Flex, Grid, GridItem, Avatar, Checkbox } from "@chakra-ui/react";
+import { Box, Text, Flex, Grid, GridItem, Avatar, Checkbox, Button } from "@chakra-ui/react";
 import React, { useState, useContext, useEffect } from "react";
 import CountryFlag from "../../base/country-flag";
 import { languageLabelFromValue } from "../../../utils/methods";
@@ -9,6 +9,7 @@ import ImageGallerySlider from "../../base/GallerySlider";
 
 
 export const SolutionDetail = ({ solution }) => {
+    const [showAllCountries, setShowAllCountries] = useState(false);
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -26,6 +27,7 @@ export const SolutionDetail = ({ solution }) => {
         transversal: 'Transversal'
     };
 
+    const displayedCountries = showAllCountries ? solution?.countries : solution?.countries?.slice(0, 4);
 
 
 
@@ -103,9 +105,22 @@ export const SolutionDetail = ({ solution }) => {
                             <Box>
                                 <Text fontSize={{ base: 8, md: 14 }} fontWeight='bold' textDecor={'underline'}>Países:</Text>
                                 <Flex align={'center'} gap={2} pt={1} flexWrap='wrap'>
-                                    {solution?.countries.map((country, index) => (
-                                        <Text key={index} fontSize={{ base: 8, md: 18 }} >{<CountryFlag country={country} />}</Text>
+                                    {displayedCountries.map((country, index) => (
+                                        <Text key={index} fontSize={{ base: 8, md: 18 }}><CountryFlag country={country} /></Text>
                                     ))}
+                                    {/* "Ver más" button to reveal all countries */}
+                                    {!showAllCountries && solution?.countries?.length > 4 && (
+                                        <Button
+                                            onClick={() => setShowAllCountries(true)}
+                                            fontSize={{ base: 8, md: 14 }}
+                                            variant="link"
+                                            color="white"
+                                            textDecoration="underline"
+                                            pl={2}
+                                        >
+                                            Ver más...
+                                        </Button>
+                                    )}
                                 </Flex>
                             </Box>
                             <Box>


### PR DESCRIPTION
Default: ![image_2025-06-04_172827708](https://github.com/user-attachments/assets/0f7de7d3-6ae5-4b39-bbaa-f17e3284a4b9)
Expanded: ![image_2025-06-04_172844231](https://github.com/user-attachments/assets/226d76e8-08e8-4a33-aa3a-22da85f925eb)

### Future possible improvements:

- "See less" button after expanding.
- Change design when expanded (too long, maybe overflow would help).
